### PR TITLE
Add krisp pricing to a readme

### DIFF
--- a/krisp-minimal/README.md
+++ b/krisp-minimal/README.md
@@ -1,0 +1,5 @@
+# Krisp Sample App
+
+This app shows how to integrate Krisp enhanced noise cancellation into your app.
+
+Krisp is available to [LiveKit Cloud](https://cloud.livekit.io/) projects on Scale or Enterprise plans. Refer to our [pricing page](https://livekit.io/pricing) for information about current pricing.


### PR DESCRIPTION
Just adding a note that Krisp requires a paid cloud project.